### PR TITLE
[TECH-6128] Fix config

### DIFF
--- a/aws_iam.tf
+++ b/aws_iam.tf
@@ -79,6 +79,7 @@ resource "aws_iam_role" "kinesis_event_role" {
 }
 
 data "aws_iam_policy_document" "kinesis_event_policy_doc" {
+  count = var.kinesis_enabled ? 1 : 0
   statement {
     effect = "Allow"
 
@@ -95,11 +96,11 @@ data "aws_iam_policy_document" "kinesis_event_policy_doc" {
 
 resource "aws_iam_policy" "kinesis_event_policy" {
   name_prefix = "guardduty-kinesis-event-"
-  policy = data.aws_iam_policy_document.kinesis_event_policy_doc.json
+  policy = data.aws_iam_policy_document.kinesis_event_policy_doc[0].json
   count = var.kinesis_enabled ? 1 : 0
 }
 
-resource "aws_iam_role_policy_attachment" "kinesis_event_attachement" {
+resource "aws_iam_role_policy_attachment" "kinesis_event_attachment" {
   role = aws_iam_role.kinesis_event_role[0].name
   policy_arn = aws_iam_policy.kinesis_event_policy[0].arn
   count = var.kinesis_enabled ? 1 : 0
@@ -201,7 +202,7 @@ resource "aws_iam_policy" "kinesis_delivery_policy" {
 EOF
 }
 
-resource "aws_iam_role_policy_attachment" "kinesis_delivery_attachement" {
+resource "aws_iam_role_policy_attachment" "kinesis_delivery_attachment" {
   role = aws_iam_role.kinesis_delivery_role[0].name
   policy_arn = aws_iam_policy.kinesis_delivery_policy[0].arn
   count = var.kinesis_enabled ? 1 : 0

--- a/aws_s3.tf
+++ b/aws_s3.tf
@@ -124,6 +124,7 @@ resource "aws_s3_bucket" "kinesis_bucket" {
 }
 
 resource "aws_s3_bucket_public_access_block" "kinesis_bucket_access" {
+  count       = var.kinesis_enabled ? 1 : 0
   bucket = aws_s3_bucket.kinesis_bucket[0].id
 
   block_public_acls       = var.block_public_acls


### PR DESCRIPTION
Running these changes within the MGMT-guardduty dir (as well as disabling kinesis) results in the following:

I've also confirmed within AWS itself that some of these resources within prod account do not exist. The one that does exist is the s3 bucket along with its dependencies. As we are not shooting logs off into EKK, Kinesis is unnecessary

```
Terraform will perform the following actions:

  # module.guardduty.aws_cloudwatch_event_target.kinesis_target[0] will be destroyed
  - resource "aws_cloudwatch_event_target" "kinesis_target" {
      - arn       = "arn:aws:firehose:eu-west-2:637085696726:deliverystream/terraform-kinesis-firehose-test-stream" -> null
      - id        = "guardduty-finding-events-send-to-es" -> null
      - role_arn  = "arn:aws:iam::637085696726:role/guardduty-kinesis-event-role" -> null
      - rule      = "guardduty-finding-events" -> null
      - target_id = "send-to-es" -> null
    }

  # module.guardduty.aws_iam_policy.kinesis_delivery_policy[0] will be destroyed
  - resource "aws_iam_policy" "kinesis_delivery_policy" {
      - arn         = "arn:aws:iam::637085696726:policy/guardduty-kinesis-delivery-20191206011426310800000003" -> null
      - id          = "arn:aws:iam::637085696726:policy/guardduty-kinesis-delivery-20191206011426310800000003" -> null
      - name        = "guardduty-kinesis-delivery-20191206011426310800000003" -> null
      - name_prefix = "guardduty-kinesis-delivery-" -> null
      - path        = "/" -> null
      - policy      = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "s3:PutObject",
                          - "s3:ListBucketMultipartUploads",
                          - "s3:ListBucket",
                          - "s3:GetObject",
                          - "s3:GetBucketLocation",
                          - "s3:AbortMultipartUpload",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:s3:::guardduty-findings-eu-west-2-637085696726/*",
                          - "arn:aws:s3:::guardduty-findings-eu-west-2-637085696726",
                        ]
                      - Sid      = ""
                    },
                  - {
                      - Action   = [
                          - "lambda:InvokeFunction",
                          - "lambda:GetFunctionConfiguration",
                        ]
                      - Effect   = "Allow"
                      - Resource = "arn:aws:lambda:eu-west-2:637085696726:function:%FIREHOSE_DEFAULT_FUNCTION%:%FIREHOSE_DEFAULT_VERSION%"
                      - Sid      = ""
                    },
                  - {
                      - Action   = [
                          - "es:ESHttpPut",
                          - "es:ESHttpPost",
                          - "es:DescribeElasticsearchDomains",
                          - "es:DescribeElasticsearchDomainConfig",
                          - "es:DescribeElasticsearchDomain",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:es:eu-west-2:637085696726:domain/ekk-33n-prod-cluster",
                          - "arn:aws:es:eu-west-2:637085696726:domain/ekk-33n-prod-cluster/*",
                        ]
                      - Sid      = ""
                    },
                  - {
                      - Action   = "es:ESHttpGet"
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:es:eu-west-2:637085696726:domain/ekk-33n-prod-cluster/_all/_settings",
                          - "arn:aws:es:eu-west-2:637085696726:domain/ekk-33n-prod-cluster/_cluster/stats",
                          - "arn:aws:es:eu-west-2:637085696726:domain/ekk-33n-prod-cluster/gdt*/_mapping/log",
                          - "arn:aws:es:eu-west-2:637085696726:domain/ekk-33n-prod-cluster/_nodes",
                          - "arn:aws:es:eu-west-2:637085696726:domain/ekk-33n-prod-cluster/_nodes/stats",
                          - "arn:aws:es:eu-west-2:637085696726:domain/ekk-33n-prod-cluster/_nodes/*/stats",
                          - "arn:aws:es:eu-west-2:637085696726:domain/ekk-33n-prod-cluster/_stats",
                          - "arn:aws:es:eu-west-2:637085696726:domain/ekk-33n-prod-cluster/gdt*/_stats",
                        ]
                      - Sid      = ""
                    },
                  - {
                      - Action   = "log:PutLogEvents"
                      - Effect   = "Allow"
                      - Resource = "arn:aws:logs:eu-west-2:637085696726:log-group:/aws/kinesisfirehose/ekk-33n-prod-cluster:log-stream:*"
                      - Sid      = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
    }

  # module.guardduty.aws_iam_policy.kinesis_event_policy[0] will be destroyed
  - resource "aws_iam_policy" "kinesis_event_policy" {
      - arn         = "arn:aws:iam::637085696726:policy/guardduty-kinesis-event-20191206012432476000000001" -> null
      - id          = "arn:aws:iam::637085696726:policy/guardduty-kinesis-event-20191206012432476000000001" -> null
      - name        = "guardduty-kinesis-event-20191206012432476000000001" -> null
      - name_prefix = "guardduty-kinesis-event-" -> null
      - path        = "/" -> null
      - policy      = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "firehose:PutRecordBatch",
                          - "firehose:PutRecord",
                        ]
                      - Effect   = "Allow"
                      - Resource = "arn:aws:firehose:eu-west-2:637085696726:deliverystream/terraform-kinesis-firehose-test-stream"
                      - Sid      = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
    }

  # module.guardduty.aws_iam_role.kinesis_event_role[0] will be destroyed
  - resource "aws_iam_role" "kinesis_event_role" {
      - arn                   = "arn:aws:iam::637085696726:role/guardduty-kinesis-event-role" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRole"
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = "events.amazonaws.com"
                        }
                      - Sid       = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2019-12-06T01:14:23Z" -> null
      - force_detach_policies = false -> null
      - id                    = "guardduty-kinesis-event-role" -> null
      - max_session_duration  = 3600 -> null
      - name                  = "guardduty-kinesis-event-role" -> null
      - path                  = "/" -> null
      - tags                  = {} -> null
      - unique_id             = "AROAZIVKEILLDLEIGWWDU" -> null
    }

  # module.guardduty.aws_iam_role_policy_attachment.kinesis_event_attachement[0] will be destroyed
  - resource "aws_iam_role_policy_attachment" "kinesis_event_attachement" {
      - id         = "guardduty-kinesis-event-role-20191206012433967500000002" -> null
      - policy_arn = "arn:aws:iam::637085696726:policy/guardduty-kinesis-event-20191206012432476000000001" -> null
      - role       = "guardduty-kinesis-event-role" -> null
    }

  # module.guardduty.aws_s3_bucket.kinesis_bucket[0] will be destroyed
  - resource "aws_s3_bucket" "kinesis_bucket" {
      - acl                         = "private" -> null
      - arn                         = "arn:aws:s3:::guardduty-kinesis-eu-west-2-637085696726" -> null
      - bucket                      = "guardduty-kinesis-eu-west-2-637085696726" -> null
      - bucket_domain_name          = "guardduty-kinesis-eu-west-2-637085696726.s3.amazonaws.com" -> null
      - bucket_regional_domain_name = "guardduty-kinesis-eu-west-2-637085696726.s3.eu-west-2.amazonaws.com" -> null
      - force_destroy               = false -> null
      - hosted_zone_id              = "Z3GKZC51ZF0DB4" -> null
      - id                          = "guardduty-kinesis-eu-west-2-637085696726" -> null
      - region                      = "eu-west-2" -> null
      - request_payer               = "BucketOwner" -> null
      - tags                        = {
          - "AccountType"  = "IAC"
          - "Application"  = "GuardDuty"
          - "CostCode"     = "Security"
          - "Environment"  = "MGMT"
          - "Name"         = "M-guardduty-kinesis-eu-west-2-637085696726-S3"
          - "SquadName"    = "33N"
          - "StackVersion" = "2.0"
        } -> null

      - lifecycle_rule {
          - abort_incomplete_multipart_upload_days = 14 -> null
          - enabled                                = true -> null
          - id                                     = "default" -> null
          - tags                                   = {} -> null

          - expiration {
              - days                         = 90 -> null
              - expired_object_delete_marker = false -> null
            }

          - noncurrent_version_transition {
              - days          = 30 -> null
              - storage_class = "STANDARD_IA" -> null
            }
          - noncurrent_version_transition {
              - days          = 60 -> null
              - storage_class = "GLACIER" -> null
            }

          - transition {
              - days          = 30 -> null
              - storage_class = "STANDARD_IA" -> null
            }
          - transition {
              - days          = 60 -> null
              - storage_class = "GLACIER" -> null
            }
        }

      - server_side_encryption_configuration {
          - rule {
              - apply_server_side_encryption_by_default {
                  - sse_algorithm = "AES256" -> null
                }
            }
        }

      - versioning {
          - enabled    = false -> null
          - mfa_delete = false -> null
        }
    }

  # module.guardduty.aws_s3_bucket_public_access_block.kinesis_bucket_access[0] will be destroyed
  - resource "aws_s3_bucket_public_access_block" "kinesis_bucket_access" {
      - block_public_acls       = false -> null
      - block_public_policy     = false -> null
      - bucket                  = "guardduty-kinesis-eu-west-2-637085696726" -> null
      - id                      = "guardduty-kinesis-eu-west-2-637085696726" -> null
      - ignore_public_acls      = false -> null
      - restrict_public_buckets = false -> null
    }

Plan: 0 to add, 0 to change, 7 to destroy.
```